### PR TITLE
Fix crypto monitor resource leak

### DIFF
--- a/services/crypto_monitor.go
+++ b/services/crypto_monitor.go
@@ -39,10 +39,10 @@ func MonitorCryptos(sendAlert func(string)) {
 					log.Printf("❌ %s: erro HTTP ao acessar CoinGecko: %v", symbol, err)
 					continue
 				}
-				defer resp.Body.Close()
 
 				if resp.StatusCode != http.StatusOK {
 					log.Printf("❌ %s: CoinGecko retornou status %d", symbol, resp.StatusCode)
+					resp.Body.Close()
 					continue
 				}
 
@@ -55,8 +55,10 @@ func MonitorCryptos(sendAlert func(string)) {
 
 				if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
 					log.Printf("❌ %s: erro ao decodificar resposta: %v", symbol, err)
+					resp.Body.Close()
 					continue
 				}
+				resp.Body.Close()
 
 				current := data.MarketData.CurrentPrice["usd"]
 				ath := data.MarketData.ATH["usd"]


### PR DESCRIPTION
## Summary
- close HTTP responses in the crypto monitor loop to avoid open file descriptors

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6840cd9184608321a57a37f031938189