### PR TITLE
Fix response body leak in crypto monitor

### DIFF
--- a/services/crypto_monitor.go
+++ b/services/crypto_monitor.go
@@ -39,10 +39,15 @@ func MonitorCryptos(sendAlert func(string)) {
 					log.Printf("❌ %s: erro HTTP ao acessar CoinGecko: %v", symbol, err)
 					continue
 				}
-				defer resp.Body.Close()
+
+				if resp == nil {
+					log.Printf("❌ %s: resposta vazia da CoinGecko", symbol)
+					continue
+				}
 
 				if resp.StatusCode != http.StatusOK {
 					log.Printf("❌ %s: CoinGecko retornou status %d", symbol, resp.StatusCode)
+					resp.Body.Close()
 					continue
 				}
 
@@ -55,8 +60,10 @@ func MonitorCryptos(sendAlert func(string)) {
 
 				if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
 					log.Printf("❌ %s: erro ao decodificar resposta: %v", symbol, err)
+					resp.Body.Close()
 					continue
 				}
+				resp.Body.Close()
 
 				current := data.MarketData.CurrentPrice["usd"]
 				ath := data.MarketData.ATH["usd"]


### PR DESCRIPTION
## Summary
- close HTTP response bodies after each request in `MonitorCryptos`

## Testing
- `go build ./...`

------
https://chatgpt.com/codex/tasks/task_e_6840d072be2c8321a8949a1ed8a0a5d1