### PR TITLE
Add formatter tests with rounding fix

### DIFF
--- a/services/formatter.go
+++ b/services/formatter.go
@@ -3,21 +3,24 @@ package services
 
 import (
 	"fmt"
+	"math"
 	"strconv"
 )
 
 // formatNumberBR formata número no estilo brasileiro (1.000.000,00)
 func formatNumberBR(val float64) string {
-	intPart := int64(val)
-	decimal := int64((val - float64(intPart)) * 100)
+	rounded := math.Round(val*100) / 100
+	intPart := int64(rounded)
+	decimal := int64(math.Round((rounded - float64(intPart)) * 100))
 	intStr := formatWithSeparator(intPart, ".")
 	return fmt.Sprintf("%s,%02d", intStr, decimal)
 }
 
 // formatNumberUS formata número no estilo americano (1,000,000.00)
 func formatNumberUS(val float64) string {
-	intPart := int64(val)
-	decimal := int64((val - float64(intPart)) * 100)
+	rounded := math.Round(val*100) / 100
+	intPart := int64(rounded)
+	decimal := int64(math.Round((rounded - float64(intPart)) * 100))
 	intStr := formatWithSeparator(intPart, ",")
 	return fmt.Sprintf("%s.%02d", intStr, decimal)
 }

--- a/services/formatter_test.go
+++ b/services/formatter_test.go
@@ -1,0 +1,41 @@
+package services
+
+import "testing"
+
+func TestFormatNumberBR(t *testing.T) {
+	tests := []struct {
+		val      float64
+		expected string
+	}{
+		{0, "0,00"},
+		{1, "1,00"},
+		{1234.56, "1.234,56"},
+		{1000000.99, "1.000.000,99"},
+	}
+
+	for _, tt := range tests {
+		got := formatNumberBR(tt.val)
+		if got != tt.expected {
+			t.Errorf("formatNumberBR(%v) = %s, want %s", tt.val, got, tt.expected)
+		}
+	}
+}
+
+func TestFormatNumberUS(t *testing.T) {
+	tests := []struct {
+		val      float64
+		expected string
+	}{
+		{0, "0.00"},
+		{1, "1.00"},
+		{1234.56, "1,234.56"},
+		{1000000.99, "1,000,000.99"},
+	}
+
+	for _, tt := range tests {
+		got := formatNumberUS(tt.val)
+		if got != tt.expected {
+			t.Errorf("formatNumberUS(%v) = %s, want %s", tt.val, got, tt.expected)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- ensure formatNumberBR/US round values to two decimals
- add table-driven tests for BR/US number formatting

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6840d074827883219c397ca327b9dd79